### PR TITLE
Bump to 1.0.10 to publish trixie packages (unblocks wlanpi-fpms)

### DIFF
--- a/.github/workflows/build-and-archive-debian-package.yml
+++ b/.github/workflows/build-and-archive-debian-package.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        distro: [bookworm,trixie]
+        distro: [trixie]
         arch: [arm64]
     
     steps:

--- a/.github/workflows/build-and-archive-debian-package.yml
+++ b/.github/workflows/build-and-archive-debian-package.yml
@@ -21,7 +21,7 @@ jobs:
     
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Build Debian package
         uses: wlan-pi/sbuild-debian-package@main
@@ -31,7 +31,7 @@ jobs:
           arch: ${{ matrix.arch }}
 
       - name: Archive artifacts and upload to GitHub
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: wlanpi-bluetooth-${{ matrix.distro }}-${{ matrix.arch }}
           path: ${{ steps.build-debian-package.outputs.deb-package }}

--- a/.github/workflows/deploy-to-packagecloud.yml
+++ b/.github/workflows/deploy-to-packagecloud.yml
@@ -19,7 +19,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        distro: [bookworm,trixie]
+        distro: [trixie]
         arch: [arm64]
 
     environment: PACKAGECLOUD
@@ -41,25 +41,27 @@ jobs:
           name: wlanpi-bluetooth-${{ matrix.distro }}-${{ matrix.arch }}
           path: ${{ steps.build-debian-package.outputs.deb-package }}
 
-      - name: Upload armhf package to raspbian/${{ matrix.distro }}
-        if: matrix.arch == 'armhf'
-        uses: danielmundi/upload-packagecloud@main
-        with:
-          package-name: ${{ steps.build-debian-package.outputs.deb-package }}
-          packagecloud-username: wlanpi
-          packagecloud-repo: dev
-          packagecloud-distrib: raspbian/${{ matrix.distro }}
-          packagecloud-token: ${{ secrets.PACKAGECLOUD_TOKEN }}
-
-      - name: Upload arm64 package to debian/${{ matrix.distro }}
-        if: matrix.arch == 'arm64'
-        uses: danielmundi/upload-packagecloud@main
-        with:
-          package-name: ${{ steps.build-debian-package.outputs.deb-package }}
-          packagecloud-username: wlanpi
-          packagecloud-repo: dev
-          packagecloud-distrib: debian/${{ matrix.distro }}
-          packagecloud-token: ${{ secrets.PACKAGECLOUD_TOKEN }}
+      # Push with the package_cloud CLI directly instead of an action so upload
+      # errors are detected: the CLI exits 0 even when a push fails (Thor bug),
+      # which has produced green runs that uploaded nothing.
+      - name: Upload package to packagecloud ${{ matrix.distro }}
+        env:
+          PACKAGECLOUD_TOKEN: ${{ secrets.PACKAGECLOUD_TOKEN }}
+          DEB_PACKAGE: ${{ steps.build-debian-package.outputs.deb-package }}
+        run: |
+          if [ -z "${DEB_PACKAGE}" ]; then
+            echo "::error::sbuild produced no .deb package"
+            exit 1
+          fi
+          case "${{ matrix.arch }}" in
+            armhf) target="wlanpi/dev/raspbian/${{ matrix.distro }}" ;;
+            *)     target="wlanpi/dev/debian/${{ matrix.distro }}" ;;
+          esac
+          sudo gem install package_cloud
+          echo "Pushing ${DEB_PACKAGE} to ${target}"
+          out=$(package_cloud push "${target}" "${DEB_PACKAGE}" 2>&1) || true
+          echo "${out}"
+          echo "${out}" | grep -q "success!"
 
   slack-workflow-status:
     if: always()

--- a/.github/workflows/deploy-to-packagecloud.yml
+++ b/.github/workflows/deploy-to-packagecloud.yml
@@ -26,7 +26,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Build Debian package
         uses: wlan-pi/sbuild-debian-package@main
@@ -36,7 +36,7 @@ jobs:
           arch: ${{ matrix.arch }}
 
       - name: Archive artifacts and upload to GitHub
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: wlanpi-bluetooth-${{ matrix.distro }}-${{ matrix.arch }}
           path: ${{ steps.build-debian-package.outputs.deb-package }}

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wlanpi-bluetooth (1.0.10) unstable; urgency=medium
+
+  * Rebuild to publish packages for Debian trixie to packagecloud
+
+ -- Josh Schmelzle <josh@joshschmelzle.com>  Fri, 10 Jul 2026 08:30:53 -0400
+
 wlanpi-bluetooth (1.0.9) unstable; urgency=medium
 
   * Adds missing Address section to pan0 networkd config file


### PR DESCRIPTION
The trixie image build fails installing wlanpi-fpms because this package has no trixie build on packagecloud:

```
wlanpi-fpms : Depends: wlanpi-bridge but it is not installable
              Depends: wlanpi-bluetooth but it is not installable
              Depends: wlanpi-server but it is not installable
```

This PR follows the same pattern as the rest of the fleet:

- Changelog bump so the PR runs a trixie test build now and the deploy publishes on merge.
- Build matrix restricted to trixie only.
- Deploy pushes with the package_cloud CLI directly and verifies each push reports success (the CLI exits 0 on errors, which has produced green deploys in this org that uploaded nothing). Fails if sbuild produces no .deb.
- Actions at current majors (includes the update-actions branch for this repo, so that PR can be closed or merged first, either works).

After merge, confirm the package appears in https://packagecloud.io/wlanpi/dev/debian/dists/trixie/main/binary-arm64/Packages

🤖 Generated with [Claude Code](https://claude.com/claude-code)
