### PR TITLE
Fix avahi configuration: preinst to guarded postinst, depend on avahi-daemon

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,13 @@
+wlanpi-bluetooth (1.0.11) unstable; urgency=medium
+
+  * Move avahi configuration from preinst to postinst: preinst runs at
+    unpack before dependencies exist, which failed the trixie image
+    build when avahi-daemon was not yet installed
+  * Guard the avahi edits on the conffile existing and drop sudo
+  * Depend on avahi-daemon so configure ordering is guaranteed
+
+ -- Josh Schmelzle <josh@joshschmelzle.com>  Fri, 10 Jul 2026 16:00:06 -0400
+
 wlanpi-bluetooth (1.0.10) unstable; urgency=medium
 
   * Rebuild to publish packages for Debian trixie to packagecloud

--- a/debian/control
+++ b/debian/control
@@ -10,6 +10,6 @@ Homepage: https://github.com/WLAN-Pi/wlanpi-bluetooth
 Package: wlanpi-bluetooth
 Architecture: any
 Multi-Arch: foreign
-Depends: ${misc:Depends}, ${shlibs:Depends}, bluez-tools
+Depends: ${misc:Depends}, ${shlibs:Depends}, bluez-tools, avahi-daemon
 Description: WLAN Pi - bluetooth
  Enable Bluetooth features on the WLAN Pi.

--- a/debian/postinst
+++ b/debian/postinst
@@ -1,0 +1,13 @@
+#!/bin/bash
+set -e
+
+# Update Avahi for pan0. Guarded: avahi-daemon is a dependency, but do
+# not fail the install if its conffile is absent for any reason.
+if [ "$1" = "configure" ] && [ -f /etc/avahi/avahi-daemon.conf ]; then
+	sed -i 's/#domain-name=local/domain-name=local/' /etc/avahi/avahi-daemon.conf
+	sed -i 's/publish-hinfo=no/publish-hinfo=yes/' /etc/avahi/avahi-daemon.conf
+	sed -i 's/publish-workstation=no/publish-workstation=yes/' /etc/avahi/avahi-daemon.conf
+	sed -i '/allow-interfaces/ {/pan0/! s/$/, pan0/ }' /etc/avahi/avahi-daemon.conf
+fi
+
+#DEBHELPER#

--- a/debian/preinst
+++ b/debian/preinst
@@ -1,7 +1,0 @@
-#!/bin/bash
-
-# Update Avahi for pan0
-sudo sed -i 's/#domain-name=local/domain-name=local/' /etc/avahi/avahi-daemon.conf
-sudo sed -i 's/publish-hinfo=no/publish-hinfo=yes/' /etc/avahi/avahi-daemon.conf
-sudo sed -i 's/publish-workstation=no/publish-workstation=yes/' /etc/avahi/avahi-daemon.conf
-sudo sed -i '/allow-interfaces/ {/pan0/! s/$/, pan0/ }' /etc/avahi/avahi-daemon.conf


### PR DESCRIPTION
The trixie image build failed unpacking wlanpi-bluetooth 1.0.10:

```
Preparing to unpack .../42-wlanpi-bluetooth_1.0.10_arm64.deb ...
sed: can't read /etc/avahi/avahi-daemon.conf: No such file or directory
```

Root cause is in this package, independent of the pi-gen stage-ordering regression (fixed separately in pi-gen-bookworm#115):

- The avahi edits ran in **preinst**, which executes at unpack time, before any dependencies are unpacked or configured. Nothing can be assumed about other packages' files there.
- The package declared **no dependency on avahi-daemon** at all, so even postinst ordering would not have been guaranteed.
- The seds used `sudo` (maintainer scripts already run as root, and sudo may not be installed) and had no existence guard.

Changes:

- Move the avahi configuration to **postinst** under `[ "$1" = "configure" ]` with a `[ -f ]` guard, and drop sudo. `#DEBHELPER#` token included.
- Add `avahi-daemon` to Depends so apt configures it before this package.
- Bump to 1.0.11: merging deploys the fixed package to packagecloud debian/trixie (verified push).

With this fix the package installs correctly regardless of what pi-gen installs in earlier stages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)